### PR TITLE
 Change assertion to prevent SchemaBuilderTest from failing due to indeterminate ordering

### DIFF
--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
@@ -30,8 +30,8 @@ import org.apache.iotdb.tsfile.write.schema.Schema;
 
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/schema/converter/SchemaBuilderTest.java
@@ -30,12 +30,13 @@ import org.apache.iotdb.tsfile.write.schema.Schema;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SchemaBuilderTest {
 
@@ -65,10 +66,15 @@ public class SchemaBuilderTest {
     String[] tsDesStrings = {
       "[s4,DOUBLE,RLE,{max_point_number=3},SNAPPY]", "[s5,INT32,TS_2DIFF,,UNCOMPRESSED]"
     };
-    int i = 0;
+    List<String> expected = Arrays.asList(tsDesStrings);
+    List<String> actual = new ArrayList<String>();
     for (IMeasurementSchema desc : timeseries) {
-      assertEquals(tsDesStrings[i++], desc.toString());
+      actual.add(desc.toString());
     }
+    assertTrue(
+        actual.size() == expected.size()
+            && actual.containsAll(expected)
+            && expected.containsAll(actual));
   }
 
   @Test
@@ -101,10 +107,15 @@ public class SchemaBuilderTest {
     String[] tsDesStrings = {
       "[s4,DOUBLE,RLE,{max_point_number=3},SNAPPY]", "[s5,INT32,TS_2DIFF,,UNCOMPRESSED]"
     };
-    int i = 0;
+    List<String> expected = Arrays.asList(tsDesStrings);
+    List<String> actual = new ArrayList<String>();
     for (IMeasurementSchema desc : timeseries) {
-      assertEquals(tsDesStrings[i++], desc.toString());
+      actual.add(desc.toString());
     }
+    assertTrue(
+        actual.size() == expected.size()
+            && actual.containsAll(expected)
+            && expected.containsAll(actual));
   }
 
   @Test
@@ -145,9 +156,14 @@ public class SchemaBuilderTest {
       "[s5,INT32,TS_2DIFF,,UNCOMPRESSED]",
       "[s6,INT64,RLE,{max_point_number=3},SNAPPY]"
     };
-    int i = 0;
+    List<String> expected = Arrays.asList(tsDesStrings);
+    List<String> actual = new ArrayList<String>();
     for (IMeasurementSchema desc : timeseries) {
-      assertEquals(tsDesStrings[i++], desc.toString());
+      actual.add(desc.toString());
     }
+    assertTrue(
+        actual.size() == expected.size()
+            && actual.containsAll(expected)
+            && expected.containsAll(actual));
   }
 }


### PR DESCRIPTION
## Description
The test `org.apache.iotdb.tsfile.write.schema.converter.SchemaBuilderTest` can fail based on the order of iteration in `HashMap`.

I found the issue using [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn test-compile -pl tsfile -am
mvn -pl tsfile edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.iotdb.tsfile.write.schema.converter.SchemaBuilderTest
```
The test can fail because it assumes that the order in `timeseries` is determinate, and can be fixed it by ignoring the order.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->
