### PR TITLE
Change assertion to prevent IoTDBInterpreterTest from failing due to indeterminate ordering

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/iotdb/IoTDBInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/iotdb/IoTDBInterpreterTest.java
@@ -30,6 +30,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 
 import static org.apache.zeppelin.iotdb.IoTDBInterpreter.DEFAULT_ENABLE_RPC_COMPRESSION;
@@ -324,7 +328,11 @@ public class IoTDBInterpreterTest {
             + "root.test.wf01.wt01.hardware\tnull\troot.test.wf01\tFLOAT\tGORILLA\tSNAPPY\tnull\tnull";
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
-    Assert.assertEquals(gt, actual.message().get(0).getData());
+    List<String> actual_list =
+        new ArrayList<String>(Arrays.asList(actual.message().get(0).getData().split("\n")));
+    List<String> expected_list = new ArrayList<String>(Arrays.asList(gt.split("\n")));
+    Assert.assertEquals(expected_list.get(0), actual_list.get(0));
+    Assert.assertEquals(new HashSet<String>(expected_list), new HashSet<String>(actual_list));
   }
 
   @Test
@@ -334,7 +342,11 @@ public class IoTDBInterpreterTest {
         "devices\tisAligned\n" + "root.test.wf02.wt02\tfalse\n" + "root.test.wf01.wt01\tfalse";
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
-    Assert.assertEquals(gt, actual.message().get(0).getData());
+    List<String> actual_list =
+        new ArrayList<String>(Arrays.asList(actual.message().get(0).getData().split("\n")));
+    List<String> expected_list = new ArrayList<String>(Arrays.asList(gt.split("\n")));
+    Assert.assertEquals(expected_list.get(0), actual_list.get(0));
+    Assert.assertEquals(new HashSet<String>(expected_list), new HashSet<String>(actual_list));
   }
 
   @Test
@@ -348,7 +360,11 @@ public class IoTDBInterpreterTest {
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
     System.out.println(actual.message().get(0).getData());
-    Assert.assertEquals(gt, actual.message().get(0).getData());
+    List<String> actual_list =
+        new ArrayList<String>(Arrays.asList(actual.message().get(0).getData().split("\n")));
+    List<String> expected_list = new ArrayList<String>(Arrays.asList(gt.split("\n")));
+    Assert.assertEquals(expected_list.get(0), actual_list.get(0));
+    Assert.assertEquals(new HashSet<String>(expected_list), new HashSet<String>(actual_list));
   }
 
   @Test
@@ -358,7 +374,11 @@ public class IoTDBInterpreterTest {
     String gt = "storage group\tttl\n" + "root.test.wf02\tnull\n" + "root.test.wf01\t12345";
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
-    Assert.assertEquals(gt, actual.message().get(0).getData());
+    List<String> actual_list =
+        new ArrayList<String>(Arrays.asList(actual.message().get(0).getData().split("\n")));
+    List<String> expected_list = new ArrayList<String>(Arrays.asList(gt.split("\n")));
+    Assert.assertEquals(expected_list.get(0), actual_list.get(0));
+    Assert.assertEquals(new HashSet<String>(expected_list), new HashSet<String>(actual_list));
   }
 
   @Test
@@ -377,7 +397,11 @@ public class IoTDBInterpreterTest {
     String gt = "storage group\n" + "root.test.wf02\n" + "root.test.wf01";
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
-    Assert.assertEquals(gt, actual.message().get(0).getData());
+    List<String> actual_list =
+        new ArrayList<String>(Arrays.asList(actual.message().get(0).getData().split("\n")));
+    List<String> expected_list = new ArrayList<String>(Arrays.asList(gt.split("\n")));
+    Assert.assertEquals(expected_list.get(0), actual_list.get(0));
+    Assert.assertEquals(new HashSet<String>(expected_list), new HashSet<String>(actual_list));
   }
 
   @Test


### PR DESCRIPTION
Some tests in the class `org.apache.zeppelin.iotdb.IoTDBInterpreterTest` can fail based on the order of iteration in `ConcurrentHashMap`. These tests are `testShowTimeseries`, `testShowDevices`, `testShowDevicesWithSg`, `testShowAllTTL`, and `testShowStorageGroup`.

I found the issue using [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn test-compile -pl tsfile -am
mvn -pl Zeppelin-interpreter edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.zeppelin.iotdb.IoTDBInterpreterTest
```
The test can fail because it assumes that the order of the data is determinate, and can be fixed it by ignoring the order.
